### PR TITLE
have DOD be a comment and not show up in published PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,10 @@ https://apivista.atlassian.net/browse/PSP2-xxxx
 - [ ] Demonstrated to team
 - [ ] Demonstrated to (or alerted) stakeholder
 
-# Definition of Done
-<!--- The generic list is below, remove any that don't apply and add any that do. -->
+<!-- Please review these before creating your final PR
+
+# Definition of Done - https://docs.google.com/document/d/13x2e3s3GajJ36MeIwn1KF3OkkUHzKfmHJTh-RhGA0Jg
+
 * **Unit tests passed** - Unit tests have passed and are accepted.
 * **Functional tests passed** - The solution works as intended from the user’s perspective.
 * **Code reviewed** - The code has been reviewed and accepted by another individual on the team. 
@@ -26,3 +28,4 @@ https://apivista.atlassian.net/browse/PSP2-xxxx
 * **Non-functional requirements met** - Any included non-functional requirements have been met, including documentation and case comments (runbooks, readme, etc).
 * **Product Owner/Relevant Parties accepts that the User Story has been solved** - The user story has been demoed and the Product Owner has given signoff.
 * **Deployed to prod** - The passed, reviewed, and approved solution is now in its final state in production.
+-->


### PR DESCRIPTION
# Description of Changes
<!--- Describe your changes in detail -->
Update the default PR template to not have DOD when published
